### PR TITLE
feat: Implement Google Sheets integration for NFT claims

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# secrets
+/secrets

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@thirdweb-dev/react": "^2.6.0-1",
         "ethers": "^5.6.9",
         "framer-motion": "^6.5.1",
+        "googleapis": "^126.0.0",
         "next": "12.2.5",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -6231,6 +6232,17 @@
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
       "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
+    "node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -7000,6 +7012,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/buffer-fill": {
       "version": "1.0.0",
@@ -7886,6 +7903,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -9111,6 +9136,11 @@
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
       "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "node_modules/extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -9598,6 +9628,62 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.1.0.tgz",
+      "integrity": "sha512-EIHuesZxNyIkUGcTQKQPMICyOpDD/bi+LJIJx+NLsSGmnS7N+xCLRX5bi4e9yAu9AlSZdVq+qlyWWVuTh/483w==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.0.0.tgz",
+      "integrity": "sha512-Ozxyi23/1Ar51wjUT2RDklK+3HxqDr8TLBNK8rBBFQ7T85iIGnXnVusauj06QyqCXRFZig8LZC+TUddWbndlpQ==",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -9744,6 +9830,59 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.0.0.tgz",
+      "integrity": "sha512-IQGjgQoVUAfOk6khqTVMLvWx26R+yPw9uLyb1MNyMQpdKiKt0Fd9sp4NWoINjyGHR8S3iw12hMTYK7O8J07c6Q==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.0.0",
+        "gcp-metadata": "^6.0.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "126.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-126.0.0.tgz",
+      "integrity": "sha512-BeCwYJfthEWUgY0ka7msSxyMuRwrwJTqL9yMlnuCxyy1JlRZwaI5ZVVp4ofwiGiNP9UuuR3Yk9CJKWQLg4Tq1A==",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.0.0.tgz",
+      "integrity": "sha512-58iSybJPQZ8XZNMpjrklICefuOuyJ0lMxfKmBqmaC0/xGT4SiOs4BE60LAOOGtBURy1n8fHa2X2YUNFEWWbXyQ==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.0.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -9756,6 +9895,18 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gtoken": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.0.1.tgz",
+      "integrity": "sha512-KcFVtoP1CVFtQu0aSk3AyAt2og66PFhZAlkUOuWKwzMLoulHXG5W5wE5xAnHb+yl3/wEFoqGW7/cDGMU8igDZQ==",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -10024,6 +10175,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
       "integrity": "sha512-o0PWwVCSp3O0wS6FvNr6xfBCHgt0m1tvPLFOCc2iFDKTRAXhB7m8klDf7ErowFH8POa6dVdGatKU5I1YYwzUyg=="
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
+      "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/hyphenate-style-name": {
       "version": "1.0.4",
@@ -10996,6 +11159,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -11267,6 +11438,25 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keccak": {
@@ -15520,6 +15710,11 @@
       "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
       "deprecated": "Please see https://github.com/lydell/urix#deprecated",
       "peer": true
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
     },
     "node_modules/use": {
       "version": "3.1.1",
@@ -20798,6 +20993,14 @@
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
       "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
+    "agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "requires": {
+        "debug": "^4.3.4"
+      }
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -21373,6 +21576,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "buffer-fill": {
       "version": "1.0.0",
@@ -22066,6 +22274,14 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -23063,6 +23279,11 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -23440,6 +23661,41 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
     },
+    "gaxios": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.1.0.tgz",
+      "integrity": "sha512-EIHuesZxNyIkUGcTQKQPMICyOpDD/bi+LJIJx+NLsSGmnS7N+xCLRX5bi4e9yAu9AlSZdVq+qlyWWVuTh/483w==",
+      "requires": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+        },
+        "node-fetch": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
+      }
+    },
+    "gcp-metadata": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.0.0.tgz",
+      "integrity": "sha512-Ozxyi23/1Ar51wjUT2RDklK+3HxqDr8TLBNK8rBBFQ7T85iIGnXnVusauj06QyqCXRFZig8LZC+TUddWbndlpQ==",
+      "requires": {
+        "gaxios": "^6.0.0",
+        "json-bigint": "^1.0.0"
+      }
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -23535,6 +23791,49 @@
         "slash": "^3.0.0"
       }
     },
+    "google-auth-library": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.0.0.tgz",
+      "integrity": "sha512-IQGjgQoVUAfOk6khqTVMLvWx26R+yPw9uLyb1MNyMQpdKiKt0Fd9sp4NWoINjyGHR8S3iw12hMTYK7O8J07c6Q==",
+      "requires": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.0.0",
+        "gcp-metadata": "^6.0.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "googleapis": {
+      "version": "126.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-126.0.0.tgz",
+      "integrity": "sha512-BeCwYJfthEWUgY0ka7msSxyMuRwrwJTqL9yMlnuCxyy1JlRZwaI5ZVVp4ofwiGiNP9UuuR3Yk9CJKWQLg4Tq1A==",
+      "requires": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      }
+    },
+    "googleapis-common": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.0.0.tgz",
+      "integrity": "sha512-58iSybJPQZ8XZNMpjrklICefuOuyJ0lMxfKmBqmaC0/xGT4SiOs4BE60LAOOGtBURy1n8fHa2X2YUNFEWWbXyQ==",
+      "requires": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.0.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -23546,6 +23845,15 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
+    },
+    "gtoken": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.0.1.tgz",
+      "integrity": "sha512-KcFVtoP1CVFtQu0aSk3AyAt2og66PFhZAlkUOuWKwzMLoulHXG5W5wE5xAnHb+yl3/wEFoqGW7/cDGMU8igDZQ==",
+      "requires": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -23750,6 +24058,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
       "integrity": "sha512-o0PWwVCSp3O0wS6FvNr6xfBCHgt0m1tvPLFOCc2iFDKTRAXhB7m8klDf7ErowFH8POa6dVdGatKU5I1YYwzUyg=="
+    },
+    "https-proxy-agent": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
+      "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
+      "requires": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      }
     },
     "hyphenate-style-name": {
       "version": "1.0.4",
@@ -24453,6 +24770,14 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "peer": true
     },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -24696,6 +25021,25 @@
       "requires": {
         "array-includes": "^3.1.5",
         "object.assign": "^4.1.3"
+      }
+    },
+    "jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "requires": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "keccak": {
@@ -27936,6 +28280,11 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
       "peer": true
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
     },
     "use": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@thirdweb-dev/react": "^2.6.0-1",
     "ethers": "^5.6.9",
     "framer-motion": "^6.5.1",
+    "googleapis": "^126.0.0",
     "next": "12.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/frontend/pages/Components/Footer.tsx
+++ b/frontend/pages/Components/Footer.tsx
@@ -5,17 +5,7 @@ const Footer = () => {
   return (
     <Box as="footer" bg="gray.800" p="4" mt="auto">
       <Text fontSize="sm">
-        &copy; {new Date().getFullYear()} All rights reserved.
-      </Text>
-      <Text fontSize="sm">
-        Built with{" "}
-        <Link href="https://nextjs.org/" isExternal>
-          Next.js
-        </Link>{" "}
-        and{" "}
-        <Link href="https://chakra-ui.com/" isExternal>
-          Chakra UI
-        </Link>
+        WeMintArt&copy; {new Date().getFullYear()} All rights reserved.
       </Text>
     </Box>
   );

--- a/frontend/pages/Components/HeroBanner.tsx
+++ b/frontend/pages/Components/HeroBanner.tsx
@@ -13,7 +13,6 @@ const HeroBanner: React.FC = () => {
       w="100vw"
       marginLeft="-50vw"
       left="50%"
-      position="relative"
     >
       <ReactPlayer
         url="https://www.youtube.com/watch?v=bEssYwezchw"
@@ -28,16 +27,18 @@ const HeroBanner: React.FC = () => {
           top: "-10%",
           position: "absolute",
         }}
-        config={{
-          youtube: {
-            playerVars: {
-              controls: 0,
-              showinfo: 0,
-              autoplay: 1,
-              mute: 1,
+        config={
+          {
+            youtube: {
+              playerVars: {
+                controls: 0,
+                showinfo: 0,
+                autoplay: 1,
+                mute: 1,
+              },
             },
-          },
-        }}
+          } as any
+        }
       />
       <Box
         position="absolute"

--- a/frontend/pages/Components/Navbar.tsx
+++ b/frontend/pages/Components/Navbar.tsx
@@ -11,16 +11,19 @@ const Navbar: React.FC = () => {
           WeMintArt
         </Link>
         <Flex>
-          <Link href="/" padding="0 1rem">
+          <Link href="/" mt="2" padding="0 1rem">
             Home
           </Link>
-          <Link href="/about" padding="0 1rem">
+          <Link href="/claim-art" mt="2" padding="0 1rem">
+            Claim Art
+          </Link>
+          <Link href="/about" mt="2" padding="0 1rem">
             About
           </Link>
-          <Link href="/gallery" padding="0 1rem">
+          <Link href="/gallery" mt="2" padding="0 1rem">
             Gallery
           </Link>
-          <Link href="/contact" padding="0 1rem">
+          <Link href="/contact" mt="2" padding="0 1rem">
             Contact
           </Link>
           <IconButton

--- a/frontend/pages/apis/checkClaimed.ts
+++ b/frontend/pages/apis/checkClaimed.ts
@@ -1,0 +1,14 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { checkIfClaimed } from "../../utils/googleSheets";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    const claimedStatusArray = await checkIfClaimed();
+    res.status(200).json(claimedStatusArray);
+  } catch (error) {
+    res.status(500).json({ error: "Failed to fetch claimed status" });
+  }
+}

--- a/frontend/pages/apis/writeToSheet.ts
+++ b/frontend/pages/apis/writeToSheet.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import path from "path";
+import { writeToSheet } from "../../utils/googleSheets";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    const data = req.body;
+    await writeToSheet(data);
+    res.status(200).json({ message: "Data written successfully" });
+  } catch (error) {
+    res.status(500).json({ error: "Failed to write data" });
+  }
+}

--- a/frontend/pages/claim-art.tsx
+++ b/frontend/pages/claim-art.tsx
@@ -1,0 +1,89 @@
+import type { NextPage } from "next";
+import { useState, useEffect } from "react";
+import Navbar from "./Components/Navbar";
+import Footer from "./Components/Footer";
+import {
+  Heading,
+  FormControl,
+  FormLabel,
+  Input,
+  Button,
+  Text,
+} from "@chakra-ui/react";
+import { writeToSheet, checkIfClaimed } from "../utils/googleSheets";
+
+const ClaimArt: NextPage = () => {
+  const [artClaimed, setArtClaimed] = useState<boolean | null>(null);
+  const [shippingDetails, setShippingDetails] = useState<string>("");
+
+  useEffect(() => {
+    const fetchClaimedStatus = async () => {
+      try {
+        const response = await fetch("/api/checkClaimed");
+        const claimedStatusArray = await response.json();
+        setArtClaimed(claimedStatusArray[0]);
+      } catch (error) {
+        console.error("Failed to fetch claimed status:", error);
+      }
+    };
+
+    fetchClaimedStatus();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const dataToWrite = [new Date().toISOString(), shippingDetails];
+    try {
+      const response = await fetch("/api/writeToSheet", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(dataToWrite),
+      });
+
+      if (response.ok) {
+        alert("Shipping details saved successfully!");
+      } else {
+        throw new Error("Failed to save shipping details");
+      }
+    } catch (error) {
+      console.error(error);
+      alert("Failed to save shipping details. Please try again.");
+    }
+  };
+
+  return (
+    <div>
+      <Navbar />
+      <main>
+        <Heading size="xl" textAlign="center" pb="3">
+          Claim Art
+        </Heading>
+        {artClaimed === null ? (
+          <Text>Loading...</Text>
+        ) : artClaimed ? (
+          <Text>This Art Has Already Been Claimed.</Text>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <FormControl id="shipping-details">
+              <FormLabel>Shipping Details</FormLabel>
+              <Input
+                type="text"
+                value={shippingDetails}
+                onChange={(e) => setShippingDetails(e.target.value)}
+              />
+              <Button m="4" colorScheme="teal" type="submit">
+                Submit
+              </Button>
+            </FormControl>
+          </form>
+        )}
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default ClaimArt;

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -97,10 +97,10 @@ const Home: NextPage = () => {
               value={walletAddress}
               onChange={(e) => setWalletAddress(e.target.value)}
             />
-            <Button mt="4" colorScheme="teal" type="submit">
+            <Button m="4" colorScheme="teal" type="submit">
               {joinButtonLabel}
             </Button>
-            <Button mt="4" colorScheme="blue" onClick={checkWhitelist}>
+            <Button m="4" colorScheme="blue" onClick={checkWhitelist}>
               Check Whitelist
             </Button>
           </FormControl>

--- a/frontend/utils/googleSheets.ts
+++ b/frontend/utils/googleSheets.ts
@@ -1,0 +1,54 @@
+import { google, sheets_v4 } from "googleapis";
+import { readFileSync } from "fs";
+import path from "path";
+
+const sheets = google.sheets("v4");
+
+const serviceAccount = JSON.parse(
+  readFileSync(
+    path.resolve(process.cwd(), "wemintart-e73ca359b40f.json"),
+    "utf8"
+  )
+);
+
+const jwtClient = new google.auth.JWT(
+  serviceAccount.client_email,
+  undefined,
+  serviceAccount.private_key,
+  ["https://www.googleapis.com/auth/spreadsheets"]
+);
+
+google.options({ auth: jwtClient });
+
+const SHEET_ID = process.env.sheetID;
+
+export async function writeToSheet(data: any) {
+  await jwtClient.authorize();
+
+  await sheets.spreadsheets.values.append({
+    spreadsheetId: SHEET_ID,
+    range: "Sheet1!A2:D401",
+    valueInputOption: "RAW",
+    insertDataOption: "INSERT_ROWS",
+    resource: {
+      values: [data],
+    },
+  } as any);
+}
+
+export async function checkIfClaimed() {
+  await jwtClient.authorize();
+
+  const response = await sheets.spreadsheets.values.get({
+    spreadsheetId: SHEET_ID,
+    range: "Sheet1!D2:D401",
+  });
+
+  const values = response.data.values;
+  if (!values || values.length === 0) {
+    throw new Error("No data found.");
+  }
+  const claimedNFTs = values.map((row) => row[0] !== "");
+
+  return claimedNFTs;
+}


### PR DESCRIPTION
- Added a new utility function to interact with Google Sheets using the googleapis library.
- Moved the Google Sheets logic to server-side API routes to ensure compatibility with Next.js and to avoid client-side issues.
- Adjusted the path resolution for the Google service account JSON file and ensured it's securely stored in a  folder.
- Updated the ClaimArt page to check if an NFT has been claimed by querying the Google Sheet.
  - If the NFT is unclaimed, a form is displayed to collect shipping details.
  - If the NFT is already claimed, an appropriate message is shown to the user.
- Enhanced error handling and added user feedback for the claim process.
- Updated .gitignore to exclude the  folder to ensure sensitive data is not committed to the repository.

Note: Ensure the Google service account has appropriate permissions and the sheetID is correctly set in the environment variables.